### PR TITLE
2025.1 compatibility check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,53 +135,47 @@ jobs:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
 
-# Release - the first release of the plugin must be done by hand, this section should be commented out until that
-#  release:
-#    name: Publish Plugin
-#    needs: [ build, verify ]
-#    if: startsWith(github.ref, 'refs/tags')
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      # Check out the current repository
-#      - name: Fetch Sources
-#        uses: actions/checkout@v4
-#        with:
-#          ref: ${{ github.event.release.tag_name }}
-#
-#      # Set up Java environment for the next steps
-#      - name: Setup Java
-#        uses: actions/setup-java@v4
-#        with:
-#          distribution: zulu
-#          java-version: 17
-#
-#      # Setup Gradle
-#      - name: Setup Gradle
-#        uses: gradle/actions/setup-gradle@v4
-#        with:
-#          gradle-home-cache-cleanup: true
-#
-#      # Update Unreleased section with the current release note
-#      - name: Patch Changelog
-#        if: ${{ steps.properties.outputs.changelog != '' }}
-#        env:
-#          CHANGELOG: ${{ steps.properties.outputs.changelog }}
-#        run: |
-#          ./gradlew patchChangelog --release-note="$CHANGELOG"
-#
-#      # Publish the plugin to JetBrains Marketplace
-#      - name: Publish Plugin
-#        env:
-#          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-#          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
-#          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-#          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
-#        run: ./gradlew publishPlugin
-#
-#      # Upload artifact as a release asset
-#      - name: Upload Release Asset
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
+  # Release
+  release:
+    name: Publish Plugin
+    needs: [ build, verify ]
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+
+    steps:
+      # Check out the current repository
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      # Set up Java environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      # Setup Gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      # ChangeLog updated as part of the release process. See the DEPLOY.md for details.
+
+      # Publish the plugin to JetBrains Marketplace
+      - name: Publish Plugin
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+        run: ./gradlew publishPlugin
+
+      # Upload artifact as a release asset
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-01-21
+
+### Changed
+
+- 2025.1 build compatibility
+
 ## [1.0.0] - 2024-09-12
 
 ### Added
 
 - Initial release of the ConfigCat IntelliJ Plugin.
 
-[Unreleased]: /compare/v1.0.0...HEAD
-[1.0.0]: /commits/v1.0.0
+[Unreleased]: https://github.com/configcat/intellij-plugin/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/configcat/intellij-plugin/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/configcat/intellij-plugin/commits/v1.0.0

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,20 @@
+# Steps to deploy
+
+## Preparation
+
+1. Run tests 
+2. Run `verifyPlugin` gradle task
+3. Increase the version in the `gradle.properties`. Update the `pluginVersion` property.
+4. Update change log
+   1. Add changes to the `CHANGELOG.md` under `Unreleased`
+   2. Run `patchChangelog` gradle task
+5. Commit & Push
+
+## Publish
+
+Use the **same version** for the git tag as in the properties file.
+
+- Via Github release
+
+  Create a new [Github release](https://github.com/configcat/intellij-plugin/releases) with a new version tag and release
+  notes.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,20 +2,17 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 
-fun properties(key: String) = providers.gradleProperty(key)
-fun environment(key: String) = providers.environmentVariable(key)
-
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
     alias(libs.plugins.intellijPlatform) // Gradle IntelliJ Plugin
     alias(libs.plugins.changelog) // Gradle Changelog Plugin
     alias(libs.plugins.kover) // Gradle Kover Plugin
-    kotlin("plugin.serialization") version libs.versions.kotlin
+    alias(libs.plugins.serialization) // Kotlin serialization
 }
 
-group = properties("pluginGroup").get()
-version = properties("pluginVersion").get()
+group = providers.gradleProperty("pluginGroup").get()
+version = providers.gradleProperty("pluginVersion").get()
 
 repositories {
     mavenCentral()
@@ -28,9 +25,9 @@ repositories {
 }
 
 dependencies {
-    implementation("com.configcat:configcat-publicapi-java-client:1.0.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation(libs.configcat.java)
+    implementation(libs.serialization.core)
+    implementation(libs.serialization.json)
 
 
     intellijPlatform {
@@ -114,7 +111,7 @@ intellijPlatform {
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
 changelog {
     groups.empty()
-    repositoryUrl = properties("pluginRepositoryUrl")
+    repositoryUrl = providers.gradleProperty("pluginRepositoryUrl")
 }
 
 // Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
@@ -130,7 +127,7 @@ kover {
 
 tasks {
     wrapper {
-        gradleVersion = properties("gradleVersion").get()
+        gradleVersion = providers.gradleProperty("gradleVersion").get()
     }
 
     publishPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 1.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 231
-pluginUntilBuild = 243.*
+pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.configcat.intellij.plugin
 pluginName = ConfigCat Feature Flags
 pluginRepositoryUrl = https://github.com/configcat/intellij-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.0
+pluginVersion = 1.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 231

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,12 @@
 [versions]
-
 # plugins
 kotlin = "2.1.0"
 changelog = "2.2.1"
 intellijPlatform = "2.1.0"
 kover = "0.8.3"
+#libraries
+configcat = "1.0.1"
+kotlinx-serialization = "1.7.3"
 
 
 [plugins]
@@ -12,3 +14,9 @@ changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
 intellijPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intellijPlatform" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
+[libraries]
+configcat-java = { module = "com.configcat:configcat-publicapi-java-client", version.ref = "configcat" }
+serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }


### PR DESCRIPTION
### Describe the purpose of your pull request

- update the pluginUntilBuild property to 251 to support the 2025.1 EAP
- updated the build.yml to handle releases
- format libs

### Related issues (only if applicable)

[Trello ticket](https://trello.com/c/11Y5aZ2e)

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
